### PR TITLE
docs: README rewrite + Husky pre-push diff-coverage check

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,1 +1,2 @@
 API_URL=http://example.com
+AUTH_SECRET=

--- a/.husky/pre-push
+++ b/.husky/pre-push
@@ -1,0 +1,1 @@
+npm run check:diff-coverage

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -22,6 +22,19 @@ Run /simplify before presenting code to the user.
 - Structure each test using the Arrange-Act-Assert pattern.
 - Tests must be human-readable: use descriptive `describe`/`it` blocks and clear, non-abbreviated variable names.
 
+### Coverage
+
+- Coverage is enforced via [Codecov](https://codecov.io), not a hand-maintained per-file `coverageThreshold` in
+  `jest.config.ts`. `codecov.yml` defines two checks: `patch` (80% of lines you added/changed in a PR must be
+  covered) and `project` (`target: auto` — total coverage must not regress from the base branch). This ratchets
+  coverage upward over time without anyone maintaining a per-file allowlist.
+- `jest.config.ts` collects coverage and emits `lcov` (among other reporters) purely for Codecov to consume — it
+  no longer fails the test run on a coverage shortfall itself.
+- A `pre-push` git hook (`scripts/check-diff-coverage.mjs`, wired via Husky's `.husky/pre-push`) mirrors Codecov's
+  `patch` check locally: it runs `jest --coverage`, diffs `src/` against `origin/develop`, and fails the push if
+  the *added* lines fall under 80% covered — so a coverage regression is caught before you even open a PR. Runs
+  automatically after `npm install` (Husky's `prepare` script wires it up).
+
 <!-- END:testing-standards -->
 
 <!-- BEGIN:naming-conventions -->

--- a/README.md
+++ b/README.md
@@ -1,46 +1,187 @@
-# ExpensApp - Web Client
+# ExpensApp — Web Client
 
-A comprehensive expense tracker application.
+[![CI](https://github.com/manufabri91/expensapp-web/actions/workflows/ci-build-test.yml/badge.svg)](https://github.com/manufabri91/expensapp-web/actions/workflows/ci-build-test.yml)
+[![codecov](https://codecov.io/gh/manufabri91/expensapp-web/branch/develop/graph/badge.svg)](https://codecov.io/gh/manufabri91/expensapp-web)
 
-Live link: https://expensapp.manuelfabri.com
+A personal expense/income tracker: multi-account, multi-currency balances, category/subcategory budgeting,
+transfers between accounts, and recurring (scheduled) transactions — with charts and a bilingual (EN/ES) UI.
+
+Live: **https://expensapp.manuelfabri.com**
 
 ![Logo](https://i.imgur.com/GkV5kWH.png)
 
-### ⚠️ DISCLAIMER ⚠️
+### ⚠️ Disclaimer
 
-In this project, I have undertaken the development of both the front-end and back-end components. However, it is important to note some of the images used have been taken from the web and belong to their authors.
+Both the front-end (this repo) and the [back-end](https://github.com/manufabri91/expensapp-api) were built by one
+person as a personal project. Some images used in the app/screenshots were sourced from the web and belong to
+their original authors.
+
+## Table of Contents
+
+- [Tech Stack](#tech-stack)
+- [Project Structure](#project-structure)
+- [Getting Started](#getting-started)
+- [Environment Variables](#environment-variables)
+- [Authentication](#authentication)
+- [Internationalization](#internationalization)
+- [Testing & Coverage](#testing--coverage)
+- [Contributing](#contributing)
+- [CI/CD](#cicd)
+- [Screenshots](#screenshots)
 
 ## Tech Stack
 
-**Client:** NextJS with [app router](https://nextjs.org/docs/app) and [Server Actions](https://nextjs.org/docs/app/api-reference/functions/server-actions), TailwindCSS
+| Concern              | Choice                                                                          |
+| --------------------- | ---------------------------------------------------------------------------------- |
+| Framework             | [Next.js 16](https://nextjs.org/docs/app) (App Router), React 19                  |
+| Styling               | Tailwind CSS v4                                                                    |
+| UI components         | [HeroUI](https://heroui.com) v3 (React Aria–based)                                |
+| Data fetching (client) | [SWR](https://swr.vercel.app), backed by [Server Actions](https://nextjs.org/docs/app/api-reference/functions/server-actions) for mutations |
+| Auth                  | Firebase Authentication (client) + [NextAuth.js v5](https://authjs.dev) (session/JWT layer) |
+| i18n                  | [next-intl](https://next-intl.dev) — English, Spanish (Spain), Spanish (Argentina) |
+| Charts                | Recharts                                                                           |
+| Date handling         | date-fns                                                                           |
+| Testing               | Jest 30 + React Testing Library                                                    |
+| Coverage              | Jest (`lcov`) + Codecov (patch/project coverage checks)                            |
+| CI                    | GitHub Actions                                                                     |
+| Deployment            | Vercel (auto-deploy from GitHub, no custom workflow needed)                        |
 
-**Server:** NextJS API Routes and Server Actions & Next Auth
+## Project Structure
 
-**Unit Test:** Jest
+```
+src/
+├── app/                # App Router routes: (landing), auth/, dashboard/, transactions/, manage/, api/
+│   └── api/             #   Next.js Route Handlers - thin pass-through proxies to the backend API
+├── components/         # Shared, reusable UI components (Button, Money, TransactionForm, ...)
+├── lib/
+│   ├── actions/         #   Server Actions - the primary way pages/components talk to the backend
+│   ├── api/             #   backendFetch/authenticatedBackendFetch - shared fetch wrappers with auth headers
+│   ├── auth/            #   NextAuth.js config, session helpers
+│   ├── providers/       #   React context providers (accounts, categories, transaction filters)
+│   └── routes.ts        #   Public vs. protected route lists, used by proxy.ts
+├── hooks/               # Shared React hooks
+├── i18n/                # next-intl request config
+├── types/               # Shared TypeScript types: dto/ (backend response shapes), enums/, viewModel/
+├── utils/               # Small, pure, unit-tested helper functions
+└── proxy.ts             # Route-protection middleware (redirects based on session state)
+```
 
-## Run Locally
+Each page under `src/app/` composes Server Components (data fetching via `lib/actions/*`) with client components
+for interactivity. See [AGENTS.md](AGENTS.md) for the conventions behind each layer (component organization,
+naming, testing) — that file is the source of truth for *how* to write code here; this README is about getting
+the project running.
 
-Clone the project
+## Getting Started
 
-`git clone https://github.com/manufabri91/expensapp-web.git`
+### Prerequisites
 
-Install e-Xpens with npm
+- Node.js (Next.js 16 requires a recent LTS version) and npm.
+- A running instance of [expensapp-api](https://github.com/manufabri91/expensapp-api) (locally via its own Docker
+  Compose setup, or pointed at a deployed environment) — this app has no database of its own, everything goes
+  through the backend.
+- A Firebase project configured for email/password authentication (this app authenticates against Firebase
+  client-side, then exchanges the resulting ID token with the backend — see [Authentication](#authentication)).
 
-`npm install`
+### 1. Clone the repository
 
-And run the project via
+```bash
+git clone https://github.com/manufabri91/expensapp-web.git
+cd expensapp-web
+```
 
-`npm run dev`
+`develop` is the default/integration branch — branch your feature work from there.
 
-And for unit tests, you can use
+### 2. Install dependencies
 
-`npm run test`
+```bash
+npm install
+```
+
+This also activates a Husky `pre-push` git hook (see [Testing & Coverage](#testing--coverage)) via the `prepare`
+script — no separate setup step needed.
+
+### 3. Configure environment variables
+
+```bash
+cp .env.example .env.local
+```
+
+Fill in the values described in [Environment Variables](#environment-variables) below.
+
+### 4. Run the dev server
+
+```bash
+npm run dev
+```
+
+Open [http://localhost:3000](http://localhost:3000).
+
+## Environment Variables
+
+| Variable      | Description                                                                                          |
+| -------------- | ------------------------------------------------------------------------------------------------------ |
+| `API_URL`      | Base URL of the backend API (e.g. `http://localhost:8080` for a local `expensapp-api`). Read server-side only — never exposed to the browser, since all backend calls go through Server Actions/Route Handlers. |
+| `AUTH_SECRET`  | Secret NextAuth.js uses to encrypt the session JWT. Any random string works locally (e.g. `openssl rand -base64 32`); must be a real secret in production. |
+
+## Authentication
+
+1. The browser authenticates directly against **Firebase** (email/password), which issues a Firebase ID token.
+2. NextAuth's Credentials provider (`src/lib/auth/config.ts`) exchanges that token with the backend's `/auth`
+   endpoints, receiving back the backend's own JWT.
+3. NextAuth wraps the backend JWT inside its own encrypted session JWT (`AUTH_SECRET`) and stores it in a
+   cookie. `src/lib/actions/*` and Route Handlers read `session.user.token` and forward it as the `Authorization`
+   header on every backend request (see `backendFetch`/`authenticatedBackendFetch`).
+4. `src/proxy.ts` is the route-protection layer: it redirects unauthenticated users away from protected routes
+   (and authenticated users away from public ones like the sign-in page), and clears a session cookie that failed
+   to refresh so it doesn't linger in a broken state.
+
+## Internationalization
+
+Powered by `next-intl`. Translation strings live in `messages/{en,es,es-AR}.json`, one namespace per feature area
+(matching the component/page tree). When adding user-facing copy, add the key to **all three** locale files.
+
+## Testing & Coverage
+
+- Every new component ships with a unit test (Jest + React Testing Library), following Arrange-Act-Assert — see
+  [AGENTS.md](AGENTS.md#testing-standards) for the full conventions.
+- Run the full suite:
+
+  ```bash
+  npm test
+  ```
+
+- **Coverage is enforced via [Codecov](https://codecov.io), not a hand-maintained per-file list.** Two checks run
+  on every PR (configured in `codecov.yml`):
+  - **`patch`** — the lines you added/changed must be ≥80% covered.
+  - **`project`** — total coverage must not regress from the base branch.
+
+  This ratchets coverage upward over time as new code lands. `jest.config.ts` just emits the `lcov` report
+  Codecov reads — it no longer fails the test run on a coverage shortfall itself.
+- **A Husky `pre-push` git hook mirrors the `patch` check locally**, so a coverage regression is caught before you
+  even open a PR: `.husky/pre-push` runs `scripts/check-diff-coverage.mjs`, which runs `jest --coverage`, diffs
+  `src/` against `origin/develop`, and fails the push if the lines you added fall under 80% covered. Activated
+  automatically by `npm install` (no separate step).
+
+## Contributing
+
+1. Branch off `develop` (the default branch) — `feature/…`, `fix/…`, or similar.
+2. Follow the conventions in [AGENTS.md](AGENTS.md) (component organization, naming, testing, coverage). It's
+   kept up to date as the actual source of truth for this codebase's style, not a generic template.
+3. Open a PR against `develop`. CI runs the full test suite and Codecov reports patch/project coverage on the PR.
+
+## CI/CD
+
+A single GitHub Actions workflow, `ci-build-test.yml`, runs on every PR to `main`/`develop`: installs dependencies,
+runs `jest --ci` with coverage, and uploads the report as a build artifact and to Codecov.
+
+There's no custom deployment workflow — production deploys happen via **Vercel**'s own GitHub integration
+(auto-deploy on push, with preview deployments per PR).
 
 ## Screenshots
 
 ![App Screenshot](https://i.imgur.com/eDAy5j3.png)
-<img width="2171" height="1014" alt="image" src="https://github.com/user-attachments/assets/6efbf936-37b0-4121-8122-8dd880191fb8" />
+<img width="2171" height="1014" alt="Transactions page" src="https://github.com/user-attachments/assets/6efbf936-37b0-4121-8122-8dd880191fb8" />
 
 ## License
 
-[MIT](https://choosealicense.com/licenses/mit/)
+See [LICENSE](LICENSE) (MIT).

--- a/package-lock.json
+++ b/package-lock.json
@@ -59,6 +59,7 @@
         "eslint-plugin-tailwindcss": "^4.0.2",
         "eslint-plugin-unused-imports": "4.4.1",
         "globals": "17.6.0",
+        "husky": "^9.1.7",
         "jest": "^30.4.2",
         "jest-environment-jsdom": "^30.4.1",
         "prettier": "3.8.4",
@@ -8282,6 +8283,22 @@
       "license": "Apache-2.0",
       "engines": {
         "node": ">=10.17.0"
+      }
+    },
+    "node_modules/husky": {
+      "version": "9.1.7",
+      "resolved": "https://registry.npmjs.org/husky/-/husky-9.1.7.tgz",
+      "integrity": "sha512-5gs5ytaNjBrh5Ow3zrvdUUY+0VxIuWVL4i9irt6friV+BqdCfmV11CQTWMiBYWHbXhco+J1kHfTOUkePhCDvMA==",
+      "dev": true,
+      "license": "MIT",
+      "bin": {
+        "husky": "bin.js"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/typicode"
       }
     },
     "node_modules/iconv-lite": {

--- a/package.json
+++ b/package.json
@@ -8,7 +8,9 @@
     "start": "next start",
     "lint": "eslint --fix",
     "format": "prettier --write .",
-    "test": "jest"
+    "test": "jest",
+    "prepare": "husky",
+    "check:diff-coverage": "node scripts/check-diff-coverage.mjs"
   },
   "dependencies": {
     "@heroui/react": "^3.2.1",
@@ -62,6 +64,7 @@
     "eslint-plugin-tailwindcss": "^4.0.2",
     "eslint-plugin-unused-imports": "4.4.1",
     "globals": "17.6.0",
+    "husky": "^9.1.7",
     "jest": "^30.4.2",
     "jest-environment-jsdom": "^30.4.1",
     "prettier": "3.8.4",

--- a/scripts/check-diff-coverage.mjs
+++ b/scripts/check-diff-coverage.mjs
@@ -1,0 +1,160 @@
+#!/usr/bin/env node
+// Enforces the same 80% rule Codecov's "patch" check applies in CI (see ../codecov.yml), but
+// locally and pre-push: only lines added/changed under src/ since the branch diverged from
+// origin/develop need to be covered - untested pre-existing code is never penalized. Run manually
+// with `npm run check:diff-coverage`; wired into .husky/pre-push automatically.
+
+import { execFileSync } from 'node:child_process';
+import { existsSync, readFileSync } from 'node:fs';
+import path from 'node:path';
+
+const THRESHOLD_PERCENT = 80;
+const BASE_REF = process.env.DIFF_BASE_REF || 'origin/develop';
+const LCOV_PATH = path.join('coverage', 'lcov.info');
+// Jest's own JS entry point, not the node_modules/.bin/jest shell wrapper - the wrapper is a
+// .cmd/.ps1 file on Windows that execFileSync can't spawn directly without a shell.
+const JEST_BIN = path.join('node_modules', 'jest', 'bin', 'jest.js');
+
+const run = (command, args) => execFileSync(command, args, { encoding: 'utf8' });
+
+const fail = (message) => {
+  console.error(`\n✖ ${message}\n`);
+  process.exit(1);
+};
+
+const findMergeBase = () => {
+  const [remote, branch] = BASE_REF.includes('/') ? BASE_REF.split('/') : [null, BASE_REF];
+  if (remote) {
+    try {
+      run('git', ['fetch', '--quiet', remote, branch]);
+    } catch {
+      console.warn(`Could not fetch ${BASE_REF}; diffing against whatever is already fetched locally.`);
+    }
+  }
+  try {
+    return run('git', ['merge-base', 'HEAD', BASE_REF]).trim();
+  } catch {
+    console.warn(`Could not find a merge base with ${BASE_REF}; skipping diff-coverage check.`);
+    process.exit(0);
+  }
+};
+
+// Parses a unified diff (-U0) into { file -> [added line numbers in the new version] }.
+const collectAddedLines = (mergeBase, files) => {
+  const addedLinesByFile = new Map();
+  for (const file of files) {
+    const diffOutput = run('git', ['diff', '-U0', mergeBase, 'HEAD', '--', file]);
+    const addedLines = [];
+    let newLineCursor = null;
+    for (const line of diffOutput.split('\n')) {
+      const hunkMatch = line.match(/^@@ -\d+(?:,\d+)? \+(\d+)/);
+      if (hunkMatch) {
+        newLineCursor = Number(hunkMatch[1]);
+        continue;
+      }
+      if (newLineCursor === null) continue;
+      if (line.startsWith('+++') || line.startsWith('---')) continue;
+      if (line.startsWith('+')) {
+        addedLines.push(newLineCursor);
+        newLineCursor += 1;
+      } else if (!line.startsWith('-')) {
+        newLineCursor += 1;
+      }
+    }
+    if (addedLines.length > 0) addedLinesByFile.set(file, addedLines);
+  }
+  return addedLinesByFile;
+};
+
+// Builds { "src/normalized/path.tsx" -> Map<lineNr, hitCount> } from Jest's lcov.info. SF: paths
+// use backslashes on Windows, so they're normalized to forward slashes to match git's output.
+const parseLcov = (lcovText) => {
+  const coverageByFile = new Map();
+  let currentLines = null;
+  for (const line of lcovText.split('\n')) {
+    if (line.startsWith('SF:')) {
+      const file = line.slice(3).trim().replace(/\\/g, '/');
+      currentLines = new Map();
+      coverageByFile.set(file, currentLines);
+    } else if (line.startsWith('DA:') && currentLines) {
+      const [nr, hits] = line.slice(3).split(',');
+      currentLines.set(Number(nr), Number(hits));
+    } else if (line.startsWith('end_of_record')) {
+      currentLines = null;
+    }
+  }
+  return coverageByFile;
+};
+
+const mergeBase = findMergeBase();
+
+const changedFiles = run('git', ['diff', '--name-only', '--diff-filter=ACMR', mergeBase, 'HEAD', '--', 'src'])
+  .split('\n')
+  .map((line) => line.trim())
+  .filter((line) => /\.(ts|tsx)$/.test(line))
+  .filter((line) => !/\.(test|spec)\.(ts|tsx)$/.test(line))
+  .filter((line) => !line.includes('__tests__/') && !line.includes('testFixtures/'));
+
+if (changedFiles.length === 0) {
+  console.log('No changed src files - skipping diff-coverage check.');
+  process.exit(0);
+}
+
+const addedLinesByFile = collectAddedLines(mergeBase, changedFiles);
+if (addedLinesByFile.size === 0) {
+  console.log('No added lines in changed files - skipping diff-coverage check.');
+  process.exit(0);
+}
+
+console.log('Running `jest --coverage` to produce a fresh coverage report...');
+try {
+  run('node', [JEST_BIN, '--coverage', '--silent', '--ci']);
+} catch {
+  fail('Tests failed - fix them before pushing.');
+}
+
+if (!existsSync(LCOV_PATH)) {
+  fail(`Expected a coverage report at ${LCOV_PATH} but none was found.`);
+}
+
+const coverageByFile = parseLcov(readFileSync(LCOV_PATH, 'utf8'));
+
+let coveredCount = 0;
+let coverableCount = 0;
+const uncoveredByFile = new Map();
+
+for (const [file, addedLines] of addedLinesByFile) {
+  const coverage = coverageByFile.get(file);
+  if (!coverage) continue; // Not instrumented (e.g. a type-only file, or untouched by any test).
+
+  for (const lineNr of addedLines) {
+    if (!coverage.has(lineNr)) continue; // Not a coverable line (blank, comment, brace, import).
+
+    coverableCount += 1;
+    if (coverage.get(lineNr) > 0) {
+      coveredCount += 1;
+    } else {
+      const list = uncoveredByFile.get(file) ?? [];
+      list.push(lineNr);
+      uncoveredByFile.set(file, list);
+    }
+  }
+}
+
+if (coverableCount === 0) {
+  console.log('No coverable added lines (only comments/imports/braces changed) - skipping diff-coverage check.');
+  process.exit(0);
+}
+
+const percentage = (coveredCount / coverableCount) * 100;
+console.log(`\nDiff coverage: ${coveredCount}/${coverableCount} lines covered (${percentage.toFixed(1)}%)\n`);
+
+if (percentage + 1e-9 < THRESHOLD_PERCENT) {
+  console.error(`Uncovered added lines (need ${THRESHOLD_PERCENT}% diff coverage):`);
+  for (const [file, lineNrs] of uncoveredByFile) {
+    console.error(`  ${file}: ${lineNrs.join(', ')}`);
+  }
+  fail(`Diff coverage ${percentage.toFixed(1)}% is below the ${THRESHOLD_PERCENT}% threshold.`);
+}
+
+console.log('Diff coverage check passed.');


### PR DESCRIPTION
## Summary
- **Husky `pre-push` hook** (`scripts/check-diff-coverage.mjs`) mirrors Codecov's `patch` check locally: runs `jest --coverage`, diffs `src/` against `origin/develop`, and blocks the push if added lines fall under 80% covered. Parses Jest's own `lcov.info` - no new coverage tooling needed. Activated automatically via `npm install`'s `prepare` script (a natural fit here since this is already an npm project - unlike the backend, where the same idea landed as a plain checked-in git hook instead, see [expensapp-api#26](https://github.com/manufabri91/expensapp-api/pull/26)).
- **README rewritten**: project structure, environment variables (including `AUTH_SECRET`, previously undocumented), an authentication flow summary, i18n section, the Codecov/Husky coverage workflow, a contributing section, and a CI/CD section - while keeping the existing live link, logo, disclaimer, screenshots, and license.
- Filled in `AUTH_SECRET` in `.env.example`, which was missing despite being required by `src/lib/auth/config.ts`.
- `AGENTS.md`'s Testing Standards section documents the new Coverage subsection.

## Test plan
- [x] `tsc --noEmit` clean, `eslint` clean.
- [x] Full Jest suite passes (122/122).
- [x] `node scripts/check-diff-coverage.mjs` manually validated against a real ~30-commit historical diff - correctly parsed `lcov.info`, computed diff coverage (1626/1764 lines, 92.2%), and passed.
- [x] Simulated a real `.husky/pre-push` invocation end-to-end and via an actual `git push` - both correctly skip when there are no changed source lines.

🤖 Generated with [Claude Code](https://claude.com/claude-code)