### PR TITLE
feat(user-settings): persist theme and locale preferences to the backend

### DIFF
--- a/src/components/Navbar/components/SettingsDrawer/ThemeSelector.tsx
+++ b/src/components/Navbar/components/SettingsDrawer/ThemeSelector.tsx
@@ -4,6 +4,8 @@ import { useTranslations } from 'next-intl';
 import { useTheme } from 'next-themes';
 import { Key } from 'react';
 import { HiComputerDesktop, HiMoon, HiSun } from 'react-icons/hi2';
+import { updateUserSettings } from '@/lib/actions/userSettings';
+import { Theme } from '@/types/dto';
 
 const THEMES = ['system', 'light', 'dark'] as const;
 
@@ -12,9 +14,14 @@ export const ThemeSelector = () => {
   const t = useTranslations('System.themeSelector');
 
   const onThemeModeChange = (key: Key | null) => {
-    if (key) {
-      setTheme(key as string);
+    if (!key) {
+      return;
     }
+    const nextTheme = key as Theme;
+    setTheme(nextTheme);
+    updateUserSettings({ theme: nextTheme }).catch((error) => {
+      console.error('[ThemeSelector] failed to persist theme to backend:', error);
+    });
   };
 
   const themeLabelMap = {

--- a/src/lib/actions/userSettings.ts
+++ b/src/lib/actions/userSettings.ts
@@ -1,0 +1,37 @@
+'use server';
+
+import { backendFetch } from '@/lib/api/backendFetch';
+import { UserSettingsRequest, UserSettingsResponse } from '@/types/dto';
+
+// The backend stores/returns theme as the Java enum name (SYSTEM/LIGHT/DARK); next-themes works
+// with lowercase values, so this module is the single place that converts between the two.
+type BackendUserSettings = {
+  theme: 'SYSTEM' | 'LIGHT' | 'DARK';
+  locale: string;
+};
+
+const fromBackend = (settings: BackendUserSettings): UserSettingsResponse => ({
+  theme: settings.theme.toLowerCase() as UserSettingsResponse['theme'],
+  locale: settings.locale as UserSettingsResponse['locale'],
+});
+
+const toBackend = (settings: UserSettingsRequest): Partial<BackendUserSettings> => ({
+  ...(settings.theme !== undefined ? { theme: settings.theme.toUpperCase() as BackendUserSettings['theme'] } : {}),
+  ...(settings.locale !== undefined ? { locale: settings.locale } : {}),
+});
+
+export const getUserSettings = async (): Promise<UserSettingsResponse> => {
+  const response = await backendFetch('/user-settings');
+  if (!response.ok) {
+    throw new Error('Failed to fetch user settings');
+  }
+  return fromBackend(await response.json());
+};
+
+export const updateUserSettings = async (settings: UserSettingsRequest): Promise<UserSettingsResponse> => {
+  const response = await backendFetch('/user-settings', { method: 'PATCH', body: toBackend(settings) });
+  if (!response.ok) {
+    throw new Error('Failed to update user settings');
+  }
+  return fromBackend(await response.json());
+};

--- a/src/lib/providers/UserSettingsProvider.tsx
+++ b/src/lib/providers/UserSettingsProvider.tsx
@@ -1,0 +1,29 @@
+'use client';
+
+import { useTheme } from 'next-themes';
+import { ReactNode, useEffect } from 'react';
+import { UserSettingsResponse } from '@/types/dto';
+
+// next-themes is localStorage-driven and can't be forced from the server without a flash, so the
+// account's theme (fetched server-side in AppProviders) is applied here once mounted instead -
+// keeping it in sync across devices/logins rather than falling back to next-themes' local default.
+export const UserSettingsProvider = ({
+  children,
+  initialSettings,
+}: {
+  children: ReactNode;
+  initialSettings: UserSettingsResponse;
+}) => {
+  const { theme, setTheme } = useTheme();
+
+  useEffect(() => {
+    if (initialSettings.theme !== theme) {
+      setTheme(initialSettings.theme);
+    }
+    // Intentionally re-runs only when the server-fetched setting changes (e.g. a fresh
+    // request/login), not on every local `theme` change - otherwise it would fight the user's
+    // own ThemeSelector clicks by reverting them back to the stale server value.
+  }, [initialSettings.theme]);
+
+  return <>{children}</>;
+};

--- a/src/lib/providers/__tests__/UserSettingsProvider.test.tsx
+++ b/src/lib/providers/__tests__/UserSettingsProvider.test.tsx
@@ -1,0 +1,48 @@
+import { render, screen } from '@testing-library/react';
+import { useTheme } from 'next-themes';
+import { UserSettingsProvider } from '@/lib/providers/UserSettingsProvider';
+
+jest.mock('next-themes', () => ({ useTheme: jest.fn() }));
+
+const mockedUseTheme = useTheme as unknown as jest.Mock;
+
+describe('UserSettingsProvider', () => {
+  it('renders its children', () => {
+    const setTheme = jest.fn();
+    mockedUseTheme.mockReturnValue({ theme: 'system', setTheme });
+
+    render(
+      <UserSettingsProvider initialSettings={{ theme: 'system', locale: 'en' }}>
+        <span>child content</span>
+      </UserSettingsProvider>
+    );
+
+    expect(screen.getByText('child content')).toBeInTheDocument();
+  });
+
+  it('applies the account theme when it differs from the current local theme', () => {
+    const setTheme = jest.fn();
+    mockedUseTheme.mockReturnValue({ theme: 'light', setTheme });
+
+    render(
+      <UserSettingsProvider initialSettings={{ theme: 'dark', locale: 'en' }}>
+        <span>child content</span>
+      </UserSettingsProvider>
+    );
+
+    expect(setTheme).toHaveBeenCalledWith('dark');
+  });
+
+  it('does not change the theme when it already matches the account theme', () => {
+    const setTheme = jest.fn();
+    mockedUseTheme.mockReturnValue({ theme: 'dark', setTheme });
+
+    render(
+      <UserSettingsProvider initialSettings={{ theme: 'dark', locale: 'en' }}>
+        <span>child content</span>
+      </UserSettingsProvider>
+    );
+
+    expect(setTheme).not.toHaveBeenCalled();
+  });
+});

--- a/src/lib/providers/__tests__/index.test.tsx
+++ b/src/lib/providers/__tests__/index.test.tsx
@@ -4,6 +4,7 @@
 import { getAccounts } from '@/lib/actions/accounts';
 import { getCategories } from '@/lib/actions/categories';
 import { getSubcategories } from '@/lib/actions/subcategories';
+import { getUserSettings } from '@/lib/actions/userSettings';
 import { auth } from '@/lib/auth';
 import { AppProviders } from '@/lib/providers';
 
@@ -11,11 +12,13 @@ jest.mock('@/lib/auth', () => ({ auth: jest.fn() }));
 jest.mock('@/lib/actions/accounts', () => ({ getAccounts: jest.fn() }));
 jest.mock('@/lib/actions/categories', () => ({ getCategories: jest.fn() }));
 jest.mock('@/lib/actions/subcategories', () => ({ getSubcategories: jest.fn() }));
+jest.mock('@/lib/actions/userSettings', () => ({ getUserSettings: jest.fn() }));
 
 const mockedAuth = auth as unknown as jest.Mock;
 const mockedGetAccounts = getAccounts as unknown as jest.Mock;
 const mockedGetCategories = getCategories as unknown as jest.Mock;
 const mockedGetSubcategories = getSubcategories as unknown as jest.Mock;
+const mockedGetUserSettings = getUserSettings as unknown as jest.Mock;
 
 describe('AppProviders', () => {
   beforeEach(() => {
@@ -54,11 +57,13 @@ describe('AppProviders', () => {
     mockedGetCategories.mockResolvedValue([]);
     mockedGetSubcategories.mockResolvedValue([]);
     mockedGetAccounts.mockResolvedValue([]);
+    mockedGetUserSettings.mockResolvedValue({ theme: 'system', locale: 'en' });
 
     await AppProviders({ children: null });
 
     expect(mockedGetAccounts).toHaveBeenCalledTimes(1);
     expect(mockedGetCategories).toHaveBeenCalledTimes(1);
     expect(mockedGetSubcategories).toHaveBeenCalledTimes(1);
+    expect(mockedGetUserSettings).toHaveBeenCalledTimes(1);
   });
 });

--- a/src/lib/providers/index.tsx
+++ b/src/lib/providers/index.tsx
@@ -3,10 +3,12 @@ import { ReactNode } from 'react';
 import { getAccounts } from '@/lib/actions/accounts';
 import { getCategories } from '@/lib/actions/categories';
 import { getSubcategories } from '@/lib/actions/subcategories';
+import { getUserSettings } from '@/lib/actions/userSettings';
 import { auth } from '@/lib/auth';
 import { hasValidSession } from '@/lib/auth/session';
 import { AccountsProvider } from '@/lib/providers/AccountsProvider';
 import { CategoriesProvider } from '@/lib/providers/CategoriesProvider';
+import { UserSettingsProvider } from '@/lib/providers/UserSettingsProvider';
 
 export const AppProviders = async ({ children }: { children: ReactNode }) => {
   const session = await auth();
@@ -18,15 +20,22 @@ export const AppProviders = async ({ children }: { children: ReactNode }) => {
     return <>{children}</>;
   }
 
-  const [categories, subcategories, accounts] = await Promise.all([getCategories(), getSubcategories(), getAccounts()]);
+  const [categories, subcategories, accounts, userSettings] = await Promise.all([
+    getCategories(),
+    getSubcategories(),
+    getAccounts(),
+    getUserSettings(),
+  ]);
 
   return (
     <SessionProvider session={session}>
-      <AccountsProvider initialAccounts={accounts}>
-        <CategoriesProvider initialCategories={categories} initialSubcategories={subcategories}>
-          {children}
-        </CategoriesProvider>
-      </AccountsProvider>
+      <UserSettingsProvider initialSettings={userSettings}>
+        <AccountsProvider initialAccounts={accounts}>
+          <CategoriesProvider initialCategories={categories} initialSubcategories={subcategories}>
+            {children}
+          </CategoriesProvider>
+        </AccountsProvider>
+      </UserSettingsProvider>
     </SessionProvider>
   );
 };

--- a/src/services/locale.ts
+++ b/src/services/locale.ts
@@ -2,15 +2,38 @@
 
 import { cookies } from 'next/headers';
 import { defaultLocale, Locale } from '@/i18n/config';
+import { getUserSettings, updateUserSettings } from '@/lib/actions/userSettings';
+import { auth } from '@/lib/auth';
+import { hasValidSession } from '@/lib/auth/session';
 
-// In this example the locale is read from a cookie. You could alternatively
-// also read it from a database, backend service, or any other source.
+// The NEXT_LOCALE cookie is the fast/guest-friendly path (read on every request by
+// i18n/request.ts). For a logged-in user, the account's saved locale is the source of truth so
+// preferences follow the account across devices/logins instead of resetting - see the
+// `usersettings` backend table.
 const COOKIE_NAME = 'NEXT_LOCALE';
 
 export async function getUserLocale(): Promise<Locale> {
+  const session = await auth();
+  if (hasValidSession(session)) {
+    try {
+      return (await getUserSettings()).locale;
+    } catch (error) {
+      console.error('[getUserLocale] failed to fetch user settings from backend:', error);
+    }
+  }
+
   return ((await cookies()).get(COOKIE_NAME)?.value as Locale) || defaultLocale;
 }
 
 export async function setUserLocale(locale: Locale) {
   (await cookies()).set(COOKIE_NAME, locale);
+
+  const session = await auth();
+  if (hasValidSession(session)) {
+    try {
+      await updateUserSettings({ locale });
+    } catch (error) {
+      console.error('[setUserLocale] failed to persist locale to backend:', error);
+    }
+  }
 }

--- a/src/types/dto/index.ts
+++ b/src/types/dto/index.ts
@@ -10,3 +10,5 @@ export * from './categoryRequest';
 export * from './monthlyBalanceSummaryResponse';
 export * from './recurringTransactionRequest';
 export * from './recurringTransactionResponse';
+export * from './userSettingsRequest';
+export * from './userSettingsResponse';

--- a/src/types/dto/userSettingsRequest.ts
+++ b/src/types/dto/userSettingsRequest.ts
@@ -1,0 +1,8 @@
+import { Locale } from '@/i18n/config';
+
+export type Theme = 'system' | 'light' | 'dark';
+
+export interface UserSettingsRequest {
+  theme?: Theme;
+  locale?: Locale;
+}

--- a/src/types/dto/userSettingsResponse.ts
+++ b/src/types/dto/userSettingsResponse.ts
@@ -1,0 +1,7 @@
+import { Locale } from '@/i18n/config';
+import { Theme } from './userSettingsRequest';
+
+export interface UserSettingsResponse {
+  theme: Theme;
+  locale: Locale;
+}


### PR DESCRIPTION
## Summary
- Theme and language are now backed by the new `/user-settings` backend endpoint instead of purely `localStorage`/cookie, so preferences follow the account across devices/logins instead of resetting to defaults.
- `services/locale.ts` prefers the backend's saved locale on every server-rendered request when authenticated (falling back to the `NEXT_LOCALE` cookie for guests / on backend failure), and persists locale changes to the backend alongside the existing cookie write.
- New `UserSettingsProvider`, seeded by `AppProviders`' existing per-request data fetch, applies the account's saved theme via `next-themes` on load/login.
- `ThemeSelector` now also persists theme changes to the backend.
- Requires backend PR: manufabri91/expensapp-api#40

## Test plan
- [x] `npm test` (32 suites / 163 tests) passes, including new `UserSettingsProvider` tests
- [x] `tsc --noEmit` and `eslint` clean on touched files
- [x] Pre-push diff-coverage hook: 100% coverage on the diff
- [ ] Manual: log in, change theme/locale in the Settings drawer, reload, confirm both persist; log in from another session/browser and confirm they carry over

🤖 Generated with [Claude Code](https://claude.com/claude-code)